### PR TITLE
refactor(CdkWorkshopStak): remove generator code.

### DIFF
--- a/lib/cdk-workshop-stack.ts
+++ b/lib/cdk-workshop-stack.ts
@@ -1,18 +1,9 @@
-import * as sns from '@aws-cdk/aws-sns';
-import * as subs from '@aws-cdk/aws-sns-subscriptions';
-import * as sqs from '@aws-cdk/aws-sqs';
 import * as cdk from '@aws-cdk/core';
 
 export class CdkWorkshopStack extends cdk.Stack {
   constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    const queue = new sqs.Queue(this, 'CdkWorkshopQueue', {
-      visibilityTimeout: cdk.Duration.seconds(300)
-    });
-
-    const topic = new sns.Topic(this, 'CdkWorkshopTopic');
-
-    topic.addSubscription(new subs.SqsSubscription(queue));
+    // STACK
   }
 }


### PR DESCRIPTION
The resulting code was auto generated. Requires to cleanup so we can create own stack.

A Fresh start